### PR TITLE
feat(eslint): Enable eslint ignoreRestSiblings by default

### DIFF
--- a/src/conf/eslint.json
+++ b/src/conf/eslint.json
@@ -27,7 +27,8 @@
     "no-unused-vars": [
       1, {
         "vars": "all",
-        "args": "none"
+        "args": "none",
+        "ignoreRestSiblings": true
       }
     ],
     "no-var": [1],


### PR DESCRIPTION
Allows use of destructuring assignment rest parameter to exclude elements.